### PR TITLE
fix for mistakes in #79

### DIFF
--- a/Backend/src/main/java/de/PSWTM/DigitalForms/controller/FormsController.java
+++ b/Backend/src/main/java/de/PSWTM/DigitalForms/controller/FormsController.java
@@ -85,7 +85,7 @@ public class FormsController implements FormsApiDelegate {
         if (form == null) {
             return ResponseEntity.badRequest().build();
         }
-        if(repository.existsById(form.getId())){
+        if(repository.existsById(form.getId()) && !form.getTemplate()){
             // ID exists Already Check if we can Update
             if(!Objects.equals(repository.findById(form.getId()).get().getOwner(), getUserID())){
                 return ResponseEntity.badRequest().build(); // Not ours

--- a/Backend/src/main/java/de/PSWTM/DigitalForms/repository/FormRepository.java
+++ b/Backend/src/main/java/de/PSWTM/DigitalForms/repository/FormRepository.java
@@ -14,9 +14,9 @@ public interface FormRepository extends MongoRepository<Form ,String> {
     @Query(value = "{ 'template' : true }", fields = "{ '_id' : 1, 'titel' : 1 , 'description':  1, 'template':  1}")
     ArrayList<Form> findAllTemplates_IdNameDescription();
 
-    @Query(value = "{'template' : false, 'owner':  ?1}")
+    @Query(value = "{'template' : false, 'owner':  ?0}")
     ArrayList<Form> findAllOwnedForm(String user);
 
-    @Query(value = "{'template' : false, 'owner':  ?1, '_id': ?2}")
+    @Query(value = "{'template' : false, 'owner':  ?0, '_id': ?1}")
     Form findOwnedFormById(String user, String id);
 }


### PR DESCRIPTION
The First Mistake is in `Backend/src/main/java/de/PSWTM/DigitalForms/controller/FormsController.java`
Caused by assuming that the "User Form" exists if an ID is Set.
It also can't be a Template...
_This worked local because I was using "Forms" from the Server and attempting to save them locally_
_In that case, the IDs were different._

The Second Mistake is in `Backend/src/main/java/de/PSWTM/DigitalForms/repository/FormRepository.java`
Query parameters do in fact start at 0
_Overlooked by the same reson as stated above_